### PR TITLE
Discard master and slave words

### DIFF
--- a/Peach2.3.9/Peach/Agent/process.py
+++ b/Peach2.3.9/Peach/Agent/process.py
@@ -79,7 +79,7 @@ class PageHeap(Monitor):
 	
 	def LocateWinDbg(self):
 		'''
-		NOTE: Update master copy in debugger.py if you change this!!!!
+		NOTE: Update main copy in debugger.py if you change this!!!!
 		'''
 		
 		import win32api, win32con

--- a/Peach2.3.9/Peach/Generators/dictionary.py
+++ b/Peach2.3.9/Peach/Generators/dictionary.py
@@ -763,7 +763,7 @@ class GeneratorList2(GeneratorList):
 	
 	This generator differs from GeneratorList by allowing one group to
 	drive the rounds, but associating different sub groups to each generator.
-	When the master group is incremented the group for the current generator is
+	When the main group is incremented the group for the current generator is
 	also incremented.  This allows more complex control of how generators
 	create data.
 	
@@ -903,11 +903,11 @@ class GeneratorList2(GeneratorList):
 	unittest = staticmethod(unittest)
 
 
-class GeneratorListGroupMaster(GeneratorList2):
+class GeneratorListGroupMain(GeneratorList2):
 	'''
 	Provides a mechanism to create in effect a group of GeneratorList2's that
-	will progress and increment together drivin by the master of the group.  This
-	Generator is the Group Master generator and controls the slaves of the
+	will progress and increment together drivin by the main of the group.  This
+	Generator is the Group Main generator and controls the subordinates of the
 	group.
 	
 	This generator comes in handy when you have two bits of data that are
@@ -924,7 +924,7 @@ class GeneratorListGroupMaster(GeneratorList2):
 		>>> groupDoLength = Group()
 		>>> groupForeachBlockDoLength = GroupForeachDo(groupForeachBlock, groupDoLength)
 		>>> 
-		>>> genBlock = GeneratorListGroupMaster(None, [
+		>>> genBlock = GeneratorListGroupMain(None, [
 		... 	groupNormalBlock,
 		... 	groupForeachBlockDoLength
 		... 	], [
@@ -942,7 +942,7 @@ class GeneratorListGroupMaster(GeneratorList2):
 		... 		]),
 		... 	])
 		>>>
-		>>> genLength = GeneratorListGroupSlave([
+		>>> genLength = GeneratorListGroupSubordinate([
 		...		None,
 		... 	None,
 		... 	], [
@@ -974,10 +974,10 @@ class GeneratorListGroupMaster(GeneratorList2):
 	
 	'''
 	
-	_slaves = []
+	_subordinates = []
 	_completed = False
 	
-	def __init__(self, group, groupList, list, slaves = None, name = None):
+	def __init__(self, group, groupList, list, subordinates = None, name = None):
 		'''
 		@type	group: Group
 		@param	group: Group this Generator belongs to
@@ -990,15 +990,15 @@ class GeneratorListGroupMaster(GeneratorList2):
 		'''
 		GeneratorList2.__init__(self, group, groupList, list, name)
 		
-		if slaves != None:
-			self._slaves = slaves
+		if subordinates != None:
+			self._subordinates = subordinates
 		else:
-			self._slaves = []
+			self._subordinates = []
 	
 	def next(self):
 		
 		if self._completed:
-			raise generator.GeneratorCompleted("Peach.dictionary.GeneratorListGroupMaster")
+			raise generator.GeneratorCompleted("Peach.dictionary.GeneratorListGroupMain")
 		
 		moveNext = True
 		
@@ -1009,30 +1009,30 @@ class GeneratorListGroupMaster(GeneratorList2):
 		except group.GroupCompleted:
 			pass
 		
-		# next the generator for each of our slaves
-		for slave in self._slaves:
+		# next the generator for each of our subordinates
+		for subordinate in self._subordinates:
 			try:
-				slave.slaveNext()
+				subordinate.subordinateNext()
 				moveNext = False
 			except group.GroupCompleted:
 				pass
 		
 		if moveNext:
-			print "GeneratorListGroupMaster.next(): Next pos [%d]" % self._curPos
+			print "GeneratorListGroupMain.next(): Next pos [%d]" % self._curPos
 		
 			if (self._curPos+1) >= len(self._list):
 				self._completed = True
 				
-				# Let the slaves know we are done
-				for slave in self._slaves:
-					slave.slaveCompleted()
+				# Let the subordinates know we are done
+				for subordinate in self._subordinates:
+					subordinate.subordinateCompleted()
 				
-				raise generator.GeneratorCompleted("Peach.dictionary.GeneratorListGroupMaster")
+				raise generator.GeneratorCompleted("Peach.dictionary.GeneratorListGroupMain")
 			
 			# Move us and everyone else to next position
 			self._curPos += 1
-			for slave in self._slaves:
-				slave.slaveNextPosition()
+			for subordinate in self._subordinates:
+				subordinate.subordinateNextPosition()
 	
 	def reset(self):
 		self._completed = False
@@ -1044,19 +1044,19 @@ class GeneratorListGroupMaster(GeneratorList2):
 		for i in self._groupList:
 			i.reset()
 		
-		for slave in self._slaves:
-			slave.reset()
+		for subordinate in self._subordinates:
+			subordinate.reset()
 
-	def addSlave(self, slave):
-		self._slaves.append(slave)
+	def addSubordinate(self, subordinate):
+		self._subordinates.append(subordinate)
 
 
-class GeneratorListGroupSlave(GeneratorList2):
+class GeneratorListGroupSubordinate(GeneratorList2):
 	'''
 	Provides a mechanism to create in effect a group of GeneratorList2's that
-	will progress and increment together drivin by the master of the group.  This
-	Generator is the slave of ghr group and is controlled by the master.  More
-	then one slave can be part of the group.
+	will progress and increment together drivin by the main of the group.  This
+	Generator is the subordinate of ghr group and is controlled by the main.  More
+	then one subordinate can be part of the group.
 	
 	This generator comes in handy when you have two bits of data that are
 	logically linked but in separate places.  An example would be a length of
@@ -1072,7 +1072,7 @@ class GeneratorListGroupSlave(GeneratorList2):
 		>>> groupDoLength = Group()
 		>>> groupForeachBlockDoLength = GroupForeachDo(groupForeachBlock, groupDoLength)
 		>>> 
-		>>> genBlock = GeneratorListGroupMaster(None, [
+		>>> genBlock = GeneratorListGroupMain(None, [
 		... 	groupNormalBlock,
 		... 	groupForeachBlockDoLength
 		... 	], [
@@ -1090,7 +1090,7 @@ class GeneratorListGroupSlave(GeneratorList2):
 		... 		]),
 		... 	])
 		>>>
-		>>> genLength = GeneratorListGroupSlave([
+		>>> genLength = GeneratorListGroupSubordinate([
 		...		None,
 		... 	None,
 		... 	], [
@@ -1121,10 +1121,10 @@ class GeneratorListGroupSlave(GeneratorList2):
 		
 	'''
 	
-	_master = None
+	_main = None
 	_completed = False
 	
-	def __init__(self, groupList = None, list = None, master = None, name = None):
+	def __init__(self, groupList = None, list = None, main = None, name = None):
 		'''
 		@type	group: Group
 		@param	group: Group this Generator belongs to
@@ -1132,8 +1132,8 @@ class GeneratorListGroupSlave(GeneratorList2):
 		@param	groupList: List of Groups to use on generators
 		@type	list: list
 		@param	list: List of Generators to iterate through
-		@type	master: GeneratorListGroupMaster
-		@param	master: The master for this groupping.  Will register self with master
+		@type	main: GeneratorListGroupMain
+		@param	main: The main for this groupping.  Will register self with main
 		@type	name: String
 		@param	name: [optional] Name for this Generator.  Used for debugging.
 		'''
@@ -1146,29 +1146,29 @@ class GeneratorListGroupSlave(GeneratorList2):
 		GeneratorList2.__init__(self, None, groupList, list, name)
 		self._name = name
 		
-		if master != None:
-			master.addSlave(self)
+		if main != None:
+			main.addSubordinate(self)
 	
 	def next(self):
 		if self._completed:
-			raise generator.GeneratorCompleted("Peach.dictionary.GeneratorListGroupSlave")
+			raise generator.GeneratorCompleted("Peach.dictionary.GeneratorListGroupSubordinate")
 	
-	def slaveNext(self):
+	def subordinateNext(self):
 		if self._groupList[self._curPos] != None:
 			self._groupList[self._curPos].next()
 		else:
-			raise group.GroupCompleted("Peach.dictionary.GeneratorListGroupSlave")
+			raise group.GroupCompleted("Peach.dictionary.GeneratorListGroupSubordinate")
 	
 	
-	def slaveNextPosition(self):
-		print self._name, "slaveNextPosition"
+	def subordinateNextPosition(self):
+		print self._name, "subordinateNextPosition"
 		self._curPos += 1
 		
 		if self._curPos >= len(self._list):
 			print self._name
 			raise Exception("%s Ran off end of generator array!!: %d of %d" % (self._name, self._curPos, len(self._list)))
 	
-	def slaveCompleted(self):
+	def subordinateCompleted(self):
 		self._completed = True
 	
 	def reset(self):

--- a/Peach2.3.9/Peach/Gui/PeachGui.py
+++ b/Peach2.3.9/Peach/Gui/PeachGui.py
@@ -222,8 +222,8 @@ try:
             try:
                 self._ClearState()
                 
-                self.masterDoc = Ft.Xml.Domlette.NonvalidatingReader.parseUri("file:"+fileName)
-                self.doc = self.masterDoc.firstChild
+                self.mainDoc = Ft.Xml.Domlette.NonvalidatingReader.parseUri("file:"+fileName)
+                self.doc = self.mainDoc.firstChild
                 self.fileName = fileName
                 self.SetTitle(self.title % fileName)
                 
@@ -323,7 +323,7 @@ try:
             
             try:
                 fout = open(self.fileName, "wb+")
-                PrettyPrint(self.masterDoc, stream=fout)
+                PrettyPrint(self.mainDoc, stream=fout)
                 fout.close()
                 
             except Exception, e:
@@ -356,7 +356,7 @@ try:
             
             try:
                 fout = open(self.fileName, "wb+")
-                PrettyPrint(self.masterDoc, stream=fout)
+                PrettyPrint(self.mainDoc, stream=fout)
                 fout.close()
                 
             except:

--- a/Peach2.3.9/Peach/mutator.py
+++ b/Peach2.3.9/Peach/mutator.py
@@ -130,8 +130,8 @@ class Mutator(object):
 #		self._infiniteMutators = []
 #		self._mutator = None
 #		
-#		self._masterCount = 0
-#		self._stateMasterCount = -1
+#		self._mainCount = 0
+#		self._stateMainCount = -1
 #		
 #		for m in self._mutators:
 #			if m.isFinite():
@@ -260,7 +260,7 @@ class Mutator(object):
 #				else:
 #					self._mutator = self._finiteMutators[self._curFinite]
 #		
-#		self._masterCount += 1
+#		self._mainCount += 1
 #	
 #	def _getRandomInfiniteMutator(self):
 #		'''
@@ -279,7 +279,7 @@ class Mutator(object):
 #		and continue when setState() is called.
 #		'''
 #		
-#		return str(self._masterCount - 2)
+#		return str(self._mainCount - 2)
 #	
 #	def setState(self, statePickle):
 #		'''
@@ -287,9 +287,9 @@ class Mutator(object):
 #		back in the same place as when we said
 #		"getState()".
 #		'''
-#		self._stateMasterCount = int(statePickle)
+#		self._stateMainCount = int(statePickle)
 #		try:
-#			for i in xrange(self._masterCount, self._stateMasterCount):
+#			for i in xrange(self._mainCount, self._stateMainCount):
 #				self.next()
 #		except:
 #			pass

--- a/Peach2.3.9/dependencies/src/4Suite-XML-1.0.2/setup.py
+++ b/Peach2.3.9/dependencies/src/4Suite-XML-1.0.2/setup.py
@@ -2,7 +2,7 @@
 ########################################################################
 # $Header: /var/local/cvsroot/4Suite/setup.py,v 1.40.2.5 2006/10/20 18:26:15 jkloth Exp $
 """
-The master installation specification
+The main installation specification
 
 Copyright 2005 Fourthought, Inc. (USA).
 Detailed license and copyright information: http://4suite.org/COPYRIGHT

--- a/Peach2.3.9/dependencies/src/4Suite-XML-1.0.2/test/Xml/Xslt/Borrowed/uo_20000817.py
+++ b/Peach2.3.9/dependencies/src/4Suite-XML-1.0.2/test/Xml/Xslt/Borrowed/uo_20000817.py
@@ -61,8 +61,8 @@ expected_1="""<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
       <xsl:otherwise>You should provide an email address for the managing editor of your channel</xsl:otherwise>
     </xsl:choose>
     <xsl:choose>
-      <xsl:when test='webMaster'/>
-      <xsl:otherwise>You should provide an email address for the webmaster of your channel</xsl:otherwise>
+      <xsl:when test='webMain'/>
+      <xsl:otherwise>You should provide an email address for the webmain of your channel</xsl:otherwise>
     </xsl:choose>
     <xsl:apply-templates mode='M0'/>
   </xsl:template>
@@ -299,7 +299,7 @@ expected_1="""<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
     <xsl:if test='parent::textinput and         (string-length(.) = 0 or          string-length(.) > 500)'>Textinput descriptions must be between 1-500 characters in length</xsl:if>
     <xsl:apply-templates mode='M2'/>
   </xsl:template>
-  <xsl:template match='copyright|pubDate|lastBuildDate|managingEditor|webMaster' mode='M2' priority='3994'>
+  <xsl:template match='copyright|pubDate|lastBuildDate|managingEditor|webMain' mode='M2' priority='3994'>
     <xsl:choose>
       <xsl:when test='string-length(.) > 1 and         string-length(.) &lt; 100'/>
       <xsl:otherwise>

--- a/Peach2.3.9/tools/minset/combine.py
+++ b/Peach2.3.9/tools/minset/combine.py
@@ -156,7 +156,7 @@ class Combine:
 	def __init__(self):
 		self.crackedModels = {}
 		self.peach = None
-		self.masterModel = None
+		self.mainModel = None
 		self.sampleFiles = []
 	
 	def getSampleFiles(self, folder):
@@ -180,10 +180,10 @@ class Combine:
 		
 		for n in self.peach:
 			if n.elementType == 'template' and n.name == modelName:
-				self.masterModel = n
+				self.mainModel = n
 				break
 		
-		if self.masterModel == None:
+		if self.mainModel == None:
 			raise Exception("Could not locate model named [%s]" % modelName)
 	
 	def crackAllSampleFiles(self):
@@ -198,7 +198,7 @@ class Combine:
 			
 			cracker = incoming.DataCracker(self.peach)
 			cracker.haveAllData = True
-			model = self.masterModel.copy(None)
+			model = self.mainModel.copy(None)
 			(rating, pos) = cracker.crackData(model, data, "setDefaultValue")
 			
 			if rating > 2:

--- a/Peach2.3.9/tools/minset/minset.py
+++ b/Peach2.3.9/tools/minset/minset.py
@@ -329,7 +329,7 @@ class PeachCoverage:
 				print "[-] %s hit %d new blocks" % (sampleFile, bbl)
 				
 			print ""
-			#print "[*] Master template is [%s] with a coverage of %d blocks" % (sampleFileMostCoverage, sampleFileMostCoverageCount)
+			#print "[*] Main template is [%s] with a coverage of %d blocks" % (sampleFileMostCoverage, sampleFileMostCoverageCount)
 			
 			# Set _traceFolder to None if we don't want
 			# cleanup to remove it
@@ -373,7 +373,7 @@ class PeachCoverage:
 						sampleFileMostCoverageCount = bbl
 				
 				print ""
-				#print "[*] Master template is [%s] with a coverage of %d blocks" % (sampleFileMostCoverage, sampleFileMostCoverageCount)
+				#print "[*] Main template is [%s] with a coverage of %d blocks" % (sampleFileMostCoverage, sampleFileMostCoverageCount)
 			
 			# Start with file with most coverage
 			minset = []
@@ -382,7 +382,7 @@ class PeachCoverage:
 			
 			for sampleFile in sampleFiles:
 				
-				# Don't repeat master file
+				# Don't repeat main file
 				if sampleFile == sampleFileMostCoverage:
 					continue
 				

--- a/Peach2.3.9/tools/minset/missing.py
+++ b/Peach2.3.9/tools/minset/missing.py
@@ -143,7 +143,7 @@ class Missing:
 	def __init__(self):
 		self.crackedModels = {}
 		self.peach = None
-		self.masterModel = None
+		self.mainModel = None
 		self.sampleFiles = []
 		self.pitFilename = None
 	
@@ -156,7 +156,7 @@ class Missing:
 	
 	def parsePitFile(self, pitFilename, modelName):
 		'''
-		Parse PIT file and load model into self.masterModel
+		Parse PIT file and load model into self.mainModel
 		'''
 		
 		print "[*] Parsing pit file:", pitFilename
@@ -168,10 +168,10 @@ class Missing:
 		
 		for n in self.peach:
 			if n.elementType == 'template' and n.name == modelName:
-				self.masterModel = n
+				self.mainModel = n
 				break
 		
-		if self.masterModel == None:
+		if self.mainModel == None:
 			raise Exception("Could not locate model named [%s]" % modelName)
 	
 	def pickleModel(self, model):
@@ -270,9 +270,9 @@ class Missing:
 				
 				buff = PublisherBuffer(None, data)
 				cracker = incoming.DataCracker(self.peach)
-				cracker.optmizeModelForCracking(self.masterModel)
+				cracker.optmizeModelForCracking(self.mainModel)
 				cracker.haveAllData = True
-				model = self.masterModel.copy(None)
+				model = self.mainModel.copy(None)
 				(rating, pos) = cracker.crackData(model, buff, "setDefaultValue")
 				
 				if rating > 2:
@@ -314,7 +314,7 @@ class Missing:
 	
 	def locateChoices(self):
 		self.choices = []
-		for node in self.masterModel.getAllChildDataElements():
+		for node in self.mainModel.getAllChildDataElements():
 			if isinstance(node, Choice):
 				self.choices.append(node)
 	
@@ -365,7 +365,7 @@ class Missing:
 					#print "Found: ", choice2.getFullDataName()
 					foundChoices.append(choice2.currentElement.name)
 			
-			# now check the master
+			# now check the main
 			for child in choice:
 				if isinstance(child, DataElement):
 					if child.name not in foundChoices:

--- a/Peach2.3.9/tools/peach-apport/apport/crashdb.py
+++ b/Peach2.3.9/tools/peach-apport/apport/crashdb.py
@@ -147,7 +147,7 @@ class CrashDatabase:
             existing = self._duplicate_search_signature(sig, id)
 
             if existing:
-                # update status of existing master bugs
+                # update status of existing main bugs
                 for (ex_id, _) in existing:
                     self._duplicate_db_sync_status(ex_id)
                 existing = self._duplicate_search_signature(sig, id)
@@ -294,7 +294,7 @@ class CrashDatabase:
         cur.execute('DELETE FROM address_signatures WHERE crash_id = ?', [id])
         self.duplicate_db.commit()
 
-    def duplicate_db_change_master_id(self, old_id, new_id):
+    def duplicate_db_change_main_id(self, old_id, new_id):
         '''Change a crash ID.'''
 
         assert self.duplicate_db, 'init_duplicate_db() needs to be called before'
@@ -699,22 +699,22 @@ class CrashDatabase:
         raise NotImplementedError('this method must be implemented by a concrete subclass')
 
     def duplicate_of(self, id):
-        '''Return master ID for a duplicate bug.
+        '''Return main ID for a duplicate bug.
 
         If the bug is not a duplicate, return None.
         '''
         raise NotImplementedError('this method must be implemented by a concrete subclass')
 
-    def close_duplicate(self, report, id, master):
-        '''Mark a crash id as duplicate of given master ID.
+    def close_duplicate(self, report, id, main):
+        '''Mark a crash id as duplicate of given main ID.
         
-        If master is None, id gets un-duplicated.
+        If main is None, id gets un-duplicated.
         '''
         raise NotImplementedError('this method must be implemented by a concrete subclass')
 
-    def mark_regression(self, id, master):
+    def mark_regression(self, id, main):
         '''Mark a crash id as reintroducing an earlier crash which is
-        already marked as fixed (having ID 'master').'''
+        already marked as fixed (having ID 'main').'''
         
         raise NotImplementedError('this method must be implemented by a concrete subclass')
 

--- a/Peach2.3.9/tools/peach-apport/apport/crashdb_impl/memory.py
+++ b/Peach2.3.9/tools/peach-apport/apport/crashdb_impl/memory.py
@@ -164,25 +164,25 @@ class CrashDatabase(apport.crashdb.CrashDatabase):
             return 'invalid'
 
     def duplicate_of(self, id):
-        '''Return master ID for a duplicate bug.
+        '''Return main ID for a duplicate bug.
 
         If the bug is not a duplicate, return None.
         '''
         return self.reports[id]['dup_of']
 
-    def close_duplicate(self, report, id, master):
-        '''Mark a crash id as duplicate of given master ID.
+    def close_duplicate(self, report, id, main):
+        '''Mark a crash id as duplicate of given main ID.
         
-        If master is None, id gets un-duplicated.
+        If main is None, id gets un-duplicated.
         '''
-        self.reports[id]['dup_of'] = master
+        self.reports[id]['dup_of'] = main
 
-    def mark_regression(self, id, master):
+    def mark_regression(self, id, main):
         '''Mark a crash id as reintroducing an earlier crash which is
-        already marked as fixed (having ID 'master').'''
+        already marked as fixed (having ID 'main').'''
 
-        assert self.reports[master]['fixed_version'] != None
-        self.reports[id]['comment'] = 'regression, already fixed in #%i' % master
+        assert self.reports[main]['fixed_version'] != None
+        self.reports[id]['comment'] = 'regression, already fixed in #%i' % main
 
     def _mark_dup_checked(self, id, report):
         '''Mark crash id as checked for being a duplicate.'''
@@ -559,7 +559,7 @@ databases = {
         self.assertEqual(self.crashes.known(self.crashes.download(2)), 
                 'http://bar.bugs.example.com/2')
 
-        # ID#3: no dup, master of ID#4
+        # ID#3: no dup, main of ID#4
         self.assertEqual(self.crashes.check_duplicate(3), None)
 
         # ID#4: dup of ID#3
@@ -606,7 +606,7 @@ databases = {
             'http://pygoo.bugs.example.com/6')
         self.assertEqual(self.crashes.check_duplicate(6), (4, None))
         self.assertEqual(self.crashes.duplicate_of(6), 4)
-        # not marked as regression, as it's now a dupe of new master bug 4
+        # not marked as regression, as it's now a dupe of new main bug 4
         self.assertFalse('comment' in self.crashes.reports[6])
 
         # check DB consistency; #5 and #6 are dupes of #3 and #4, so no new
@@ -806,7 +806,7 @@ databases = {
                 self.crashes.get_comment_url(r3, r_id))
 
         # changing ID also works on address signatures
-        self.crashes.duplicate_db_change_master_id(r_id, r3_id)
+        self.crashes.duplicate_db_change_main_id(r_id, r3_id)
         self.crashes.duplicate_db_publish(self.dupdb_dir)
         self.assertEqual(self.crashes.known(r), 
                 self.crashes.get_comment_url(r, r3_id))
@@ -821,8 +821,8 @@ databases = {
 
         self.assertEqual(self.crashes._duplicate_db_dump(), {})
 
-    def test_change_master_id(self):
-        '''duplicate_db_change_master_id()'''
+    def test_change_main_id(self):
+        '''duplicate_db_change_main_id()'''
 
         # db not yet initialized
         self.assertRaises(AssertionError, self.crashes.check_duplicate, 0)
@@ -838,7 +838,7 @@ databases = {
              self.crashes.download(2).crash_signature(): (2, None)})
 
         # invalid ID (raising KeyError is *hard*, so it's not done)
-        self.crashes.duplicate_db_change_master_id(5, 99)
+        self.crashes.duplicate_db_change_main_id(5, 99)
 
         # nevertheless, this should not change the DB
         self.assertEqual(self.crashes._duplicate_db_dump(), 
@@ -846,7 +846,7 @@ databases = {
              self.crashes.download(2).crash_signature(): (2, None)})
 
         # valid ID
-        self.crashes.duplicate_db_change_master_id(2, 99)
+        self.crashes.duplicate_db_change_main_id(2, 99)
 
         # check DB consistency
         self.assertEqual(self.crashes._duplicate_db_dump(), 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.